### PR TITLE
Fix date display issue in event edit form and normalize member events…

### DIFF
--- a/src/components/EventForm.jsx
+++ b/src/components/EventForm.jsx
@@ -59,13 +59,21 @@ const EventForm = ({ event, onSuccess, onCancel }) => {
     fetchMembers()
   }, [])
 
+  // Helper function to convert UTC date string to local date with same calendar date
+  const parseUTCDate = (dateString) => {
+    if (!dateString) return null
+    const utcDate = new Date(dateString)
+    // Create a new date in local timezone with the same year/month/day as UTC
+    return new Date(utcDate.getUTCFullYear(), utcDate.getUTCMonth(), utcDate.getUTCDate())
+  }
+
   // Load event data for edit mode
   useEffect(() => {
     if (event) {
       setFormData({
         event: event.event || '',
-        start: event.start ? new Date(event.start) : null,
-        end: event.end ? new Date(event.end) : null,
+        start: parseUTCDate(event.start),
+        end: parseUTCDate(event.end),
         details: event.details || '',
         cancelled: event.cancelled || false,
         pdfFile: event.pdfFile || '',

--- a/src/services/restdbService.js
+++ b/src/services/restdbService.js
@@ -293,7 +293,23 @@ export const unregisterFromEvent = async (eventId, memberId) => {
 
 export const getMemberEvents = async (memberId) => {
   const url = `${api}members/${memberId}/events`;
-  return get(url);
+  const events = await get(url);
+
+  // Handle edge case where API might return empty or null
+  if (!events || !Array.isArray(events)) {
+    console.warn('getMemberEvents: Unexpected response format', events);
+    return [];
+  }
+
+  // Normalize the event data to ensure consistent field names
+  // Backend should return eventTitle, eventStart, eventEnd
+  // But may return event, start, end (legacy format)
+  return events.map(event => ({
+    _id: event._id,
+    eventTitle: event.eventTitle || event.event,
+    eventStart: event.eventStart || event.start,
+    eventEnd: event.eventEnd || event.end
+  }));
 };
 
 export const getEventAttendees = async (eventId) => {


### PR DESCRIPTION
This pull request improves the handling and normalization of event date fields in both the frontend form and backend service layer. The main changes ensure that event dates are consistently parsed and displayed in the local timezone, and that event data returned from the backend is normalized to use consistent field names, supporting both legacy and current formats.

**Event date handling improvements:**

* Added a helper function `parseUTCDate` in `EventForm.jsx` to convert UTC date strings to local dates with the same calendar date, ensuring correct date display in forms.
* Updated the form data initialization in `EventForm.jsx` to use `parseUTCDate` for `start` and `end` fields, replacing the previous direct `Date` parsing.

**Backend event data normalization:**

* Modified `getMemberEvents` in `restdbService.js` to handle unexpected API responses gracefully, returning an empty array if the response format is invalid.
* Normalized event objects returned by `getMemberEvents` to consistently use `eventTitle`, `eventStart`, and `eventEnd` fields, supporting both legacy (`event`, `start`, `end`) and current formats.