### PR TITLE
Add OpenCode custom commands, agent skills, and MCP server configuration

### DIFF
--- a/.opencode/commands/brainstorm.md
+++ b/.opencode/commands/brainstorm.md
@@ -1,0 +1,12 @@
+---
+description: Brainstorm new features with the birding expert panel
+agent: ken
+---
+
+Convene the expert panel to brainstorm feature ideas for the Fredericksburg Birding Club website.
+
+Topic: $ARGUMENTS
+
+If no topic was provided, ask what area of the site or what type of feature they would like to explore ideas for.
+
+Consider the current state of the website and propose features that are practical for a ~30 member club with a volunteer-maintained React/MUI website.

--- a/.opencode/commands/build.md
+++ b/.opencode/commands/build.md
@@ -1,0 +1,13 @@
+---
+description: Run production build and fix any errors
+---
+
+Run `npm run build` and check for any errors.
+
+If the build fails:
+1. Read the error output carefully
+2. Fix each error
+3. Re-run the build to verify the fix
+4. Repeat until the build succeeds
+
+Report a summary of what was fixed when done.

--- a/.opencode/commands/lint.md
+++ b/.opencode/commands/lint.md
@@ -1,0 +1,11 @@
+---
+description: Run ESLint and Prettier, fix all issues
+---
+
+Run linting and formatting checks on the project:
+
+1. Run `npx eslint .` and fix any errors or warnings found
+2. Run `npx prettier --check .` and fix any formatting issues with `npx prettier --write .`
+3. Re-run both checks to confirm everything passes
+
+Focus on files in `src/` and `api/`. Report a summary of what was fixed.

--- a/.opencode/commands/new-component.md
+++ b/.opencode/commands/new-component.md
@@ -1,0 +1,16 @@
+---
+description: Scaffold a new component following project conventions
+---
+
+Create a new React component named `$ARGUMENTS` following the fredbirds project conventions:
+
+1. Create the file at `src/components/$ARGUMENTS.jsx`
+2. Use the standard component structure:
+   - Functional component with `export default function $ARGUMENTS() { ... }`
+   - MUI `sx` prop for all styling (no CSS modules, no Tailwind, no styled-components)
+   - Import ordering per AGENTS.md: React first, then third-party, then MUI, then local components, then services
+3. Use single quotes, 4-space indentation, no semicolons, no trailing commas
+4. Add a basic JSX structure with a `PageContainer` wrapper if it is a page component
+5. Include any props that were described along with the component name
+
+If the component name was not provided, ask what the component should be called and what it should do.

--- a/.opencode/commands/review.md
+++ b/.opencode/commands/review.md
@@ -1,0 +1,22 @@
+---
+description: Review current changes for quality and conventions
+agent: plan
+---
+
+Review the current uncommitted changes in this project:
+
+!`git diff`
+!`git diff --cached`
+!`git status`
+
+Check for:
+1. **Code style**: Single quotes, no semicolons, 4-space indent, no trailing commas
+2. **MUI conventions**: Using `sx` prop only (no CSS modules, styled-components, or inline styles)
+3. **Import ordering**: React -> third-party -> hooks -> MUI styles -> MUI components -> MUI icons -> local components -> services -> CSS
+4. **Access control**: Are protected features properly gated with `MemberAccessControl` or `ProtectedRoute`?
+5. **Error handling**: Are API calls wrapped in try/catch with proper error state using `useState` and `Alert`?
+6. **API calls**: Are they going through service files in `src/services/` rather than directly from components?
+7. **Accessibility**: Proper ARIA labels, alt text, keyboard navigation
+8. **Component patterns**: Functional components only, default exports, proper naming conventions
+
+Provide specific, actionable feedback for each issue found. Reference file paths and line numbers.

--- a/.opencode/skills/access-control/SKILL.md
+++ b/.opencode/skills/access-control/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: access-control
+description: Role-based access control system with four tiers for the fredbirds project
+---
+
+## Access Control System
+
+### Four-Tier Role Hierarchy
+Defined in `src/hooks/useUserRole.js`:
+
+| Level | Constant | Numeric | Who |
+|-------|----------|---------|-----|
+| PUBLIC | `ACCESS_LEVELS.PUBLIC` | 0 | Unauthenticated visitors |
+| MEMBER | `ACCESS_LEVELS.MEMBER` | 1 | Authenticated club members |
+| OFFICER | `ACCESS_LEVELS.OFFICER` | 2 | Club officers |
+| ADMIN | `ACCESS_LEVELS.ADMIN` | 3 | Administrators |
+
+Higher levels inherit access from lower levels (an ADMIN can see everything a MEMBER can).
+
+### How to Import
+```jsx
+import { ACCESS_LEVELS } from '../hooks/useUserRole'
+import { useUserRole } from '../hooks/useUserRole'
+```
+
+### The useUserRole Hook
+Returns:
+```jsx
+const { userRole, roleLoading, hasAccess } = useUserRole()
+```
+- `userRole` -- current user's role string (e.g., `'member'`, `'officer'`)
+- `roleLoading` -- boolean, true while role is being determined
+- `hasAccess(requiredLevel)` -- function that checks if user meets the required level
+
+### Protecting Routes (in App.jsx)
+Two wrapper components are used in route definitions:
+
+**ProtectedRoute** -- requires authentication (any logged-in user):
+```jsx
+<Route path="/dashboard" element={
+    <ProtectedRoute>
+        <MemberDashboard />
+    </ProtectedRoute>
+} />
+```
+
+**MemberAccessControl** -- requires a specific role level:
+```jsx
+<Route path="/officer-tools" element={
+    <ProtectedRoute>
+        <MemberAccessControl requiredLevel={ACCESS_LEVELS.OFFICER}>
+            <OfficerTools />
+        </MemberAccessControl>
+    </ProtectedRoute>
+} />
+```
+
+### Protecting UI Elements Within Components
+Use `hasAccess()` to conditionally render buttons, sections, or actions:
+```jsx
+const { hasAccess } = useUserRole()
+
+{hasAccess(ACCESS_LEVELS.OFFICER) && (
+    <Button onClick={handleEdit}>Edit</Button>
+)}
+```
+
+### Auth State
+Auth0 provides the authentication layer:
+```jsx
+import { useAuth0 } from '@auth0/auth0-react'
+const { user, isAuthenticated, isLoading, loginWithRedirect, logout } = useAuth0()
+```
+
+### Role Determination Order
+The hook checks roles in this order:
+1. Auth0 `app_metadata.role`
+2. Auth0 custom claims (`https://birdingclub.com/roles`)
+3. Backend API lookup via `getUserRole()` from restdbService
+4. Falls back to `ACCESS_LEVELS.PUBLIC`
+
+### Common Access Patterns
+- **Public pages**: Home, About, Contact, FAQs, Events, News, Resources -- no protection needed
+- **Member pages**: Dashboard, Profile, Members Directory, Photos -- wrap in `ProtectedRoute`
+- **Officer pages**: Officer Tools, Manage Events/Members/Announcements -- wrap in `MemberAccessControl` with `ACCESS_LEVELS.OFFICER`
+- **Admin pages**: Admin Panel -- wrap in `MemberAccessControl` with `ACCESS_LEVELS.ADMIN`

--- a/.opencode/skills/api-integration/SKILL.md
+++ b/.opencode/skills/api-integration/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: api-integration
+description: Backend API patterns, service file conventions, and error handling for the fredbirds project
+---
+
+## API Integration Rules
+
+### Service Architecture
+- **ALL API calls MUST go through service files** in `src/services/`
+- **NEVER call APIs directly from components** -- always import from a service
+- Four service files exist:
+  - `restdbService.js` -- Main backend API (Heroku/MongoDB)
+  - `ebirdService.js` -- eBird API integration
+  - `cloudinaryService.js` -- Image upload/management
+  - `weatherService.js` -- OpenWeather API
+
+### Backend API Base URL
+```
+https://fredbirds-api.herokuapp.com/
+```
+
+### Service File Conventions
+- Named exports for each function: `export const getEvents = async () => { ... }`
+- Also export a default object containing all named exports
+- Internal helper functions (`get`, `post`, `patch`, `del`) are private to the service
+- Services throw on HTTP errors: `throw new Error(\`HTTP \${res.status}: \${res.statusText}\`)`
+
+### Error Handling Pattern in Components
+Always use this pattern when calling services from components:
+
+```jsx
+const [error, setError] = useState(null)
+const [loading, setLoading] = useState(false)
+
+const fetchData = async () => {
+    setLoading(true)
+    try {
+        const data = await someServiceFunction()
+        // update state with data
+    } catch (err) {
+        console.error('Error doing X:', err)
+        setError(err.message || 'Fallback error message')
+    } finally {
+        setLoading(false)
+    }
+}
+```
+
+### Displaying Errors
+Use MUI Alert component with dismiss capability:
+
+```jsx
+import Alert from '@mui/material/Alert'
+
+{error && (
+    <Alert severity="error" onClose={() => setError(null)}>
+        {error}
+    </Alert>
+)}
+```
+
+### Data Fetching
+- Fetch data in `useEffect` or event handlers -- no React Query or SWR
+- Use `sessionStorage` for caching where appropriate (e.g., rare birds data)
+- Loading states use `useState` booleans (`loading`, `isLoading`)
+
+### Environment Variables
+All client-side API keys use the `VITE_` prefix and are accessed via `import.meta.env.VITE_*`:
+- `VITE_EBIRD_KEY` -- eBird API
+- `VITE_OPENWEATHER_API_KEY` -- OpenWeather
+- `VITE_GOOGLE_MAPS_API_KEY` -- Google Maps
+- `VITE_CLOUDINARY_CLOUD_NAME`, `VITE_CLOUDINARY_UPLOAD_PRESET` -- Cloudinary
+- `VITE_AUTH0_DOMAIN`, `VITE_AUTH0_CLIENT_ID` -- Auth0

--- a/.opencode/skills/mui-patterns/SKILL.md
+++ b/.opencode/skills/mui-patterns/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: mui-patterns
+description: MUI v5 styling conventions, theme values, and component patterns for the fredbirds project
+---
+
+## MUI Styling Rules
+
+This project uses MUI v5 exclusively with the `sx` prop. Follow these rules strictly:
+
+### Styling Approach
+- **ONLY use the `sx` prop** for all component styling
+- **NEVER use** CSS modules, Tailwind, styled-components, `makeStyles`, or inline `style` attributes
+- **NEVER add** significant styles to `src/index.css` -- it is intentionally minimal (global resets only)
+- Use `useTheme()` and `useMediaQuery()` for dynamic theme/responsive logic
+
+### Responsive Design
+- Use MUI responsive shorthand for breakpoints within `sx`:
+  ```jsx
+  sx={{ px: { xs: 2, sm: 3, md: 6 }, fontSize: { xs: '0.875rem', md: '1rem' } }}
+  ```
+- Use `useMediaQuery(theme.breakpoints.down('md'))` for conditional rendering logic
+
+### Theme Values (defined in App.jsx)
+
+**Palette:**
+- Primary: `#2d5016` (Deep Forest Green), light: `#4a7c59`, dark: `#1e3910`
+- Secondary: `#c17817` (Golden Amber), light: `#d4a574`, dark: `#8f570f`
+- Background: default `#f8f9fa`, paper `#ffffff`
+- Text: primary `#1a1a1a`, secondary `#5c5c5c`
+- Accent colors: blue `#5b9bd5`, brown `#8b6f47`, teal `#2c7873`, sage `#6b8e6f`
+
+**Typography:**
+- Body font: `"Inter", "Roboto", "Helvetica", "Arial", sans-serif`
+- Heading font: `"Outfit", sans-serif`
+- Base font size: 16px (not the MUI default of 14px)
+
+Always reference theme colors via `theme.palette.*` or `sx={{ color: 'primary.main' }}` rather than hardcoding hex values.
+
+### Common Component Patterns
+
+**Page components** use `PageContainer` from `src/components/common/PageContainer.jsx`:
+```jsx
+import PageContainer from './common/PageContainer'
+
+export default function MyPage() {
+    return (
+        <PageContainer title="Page Title">
+            {/* page content */}
+        </PageContainer>
+    )
+}
+```
+
+**Dialogs** use `AppDialog` from `src/components/common/AppDialog.jsx` (not raw MUI Dialog):
+```jsx
+import AppDialog from './common/AppDialog'
+```
+
+**Cards** use `AppCard` from `src/components/common/AppCard.jsx`:
+```jsx
+import AppCard from './common/AppCard'
+```
+
+**Confirmation dialogs** use `ConfirmDialog` from `src/components/common/ConfirmDialog.jsx`.
+
+### Import Style for MUI
+- Import MUI components individually (not from barrel exports):
+  ```jsx
+  // Correct
+  import Box from '@mui/material/Box'
+  import Typography from '@mui/material/Typography'
+
+  // Avoid
+  import { Box, Typography } from '@mui/material'
+  ```
+- Import MUI icons individually:
+  ```jsx
+  import EditIcon from '@mui/icons-material/Edit'
+  ```

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "https://opencode.ai/config.json",
+    "instructions": [
+        "COMPONENT_GUIDE.md",
+        "ACCESS_CONTROL_GUIDE.md",
+        "BACKEND_API_REQUIREMENTS.md"
+    ],
+    "formatter": {
+        "prettier": {
+            "command": ["npx", "prettier", "--write", "$FILE"],
+            "extensions": [".js", ".jsx", ".json", ".css", ".md"]
+        }
+    },
+    "mcp": {
+        "context7": {
+            "type": "remote",
+            "url": "https://mcp.context7.com/mcp",
+            "enabled": true
+        },
+        "github": {
+            "type": "remote",
+            "url": "https://api.githubcopilot.com/mcp/",
+            "enabled": true
+        },
+        "mongodb": {
+            "type": "local",
+            "command": ["npx", "-y", "mongodb-mcp-server@latest", "--readOnly"],
+            "environment": {
+                "MDB_MCP_CONNECTION_STRING": "{env:MONGODB_CONNECTION_STRING}"
+            },
+            "enabled": false
+        },
+        "auth0": {
+            "type": "local",
+            "command": ["npx", "-y", "@auth0/auth0-mcp-server", "run", "--read-only"],
+            "enabled": false
+        }
+    }
+}


### PR DESCRIPTION
Configure opencode.json with instruction references, Prettier auto-formatter, and four MCP servers (Context7, GitHub, MongoDB, Auth0). Add five custom commands (/build, /lint, /new-component, /review, /brainstorm) and three agent skills (mui-patterns, api-integration, access-control) to improve agent context and streamline common workflows.