### PR TITLE
HOTFIX: Fix email template exports causing ReferenceError

### DIFF
--- a/src/utils/announcementEmailUtils.js
+++ b/src/utils/announcementEmailUtils.js
@@ -1,11 +1,12 @@
 import { generateAnnouncementEmail } from './emailTemplates';
-import { sendBulkEmails } from './emailBatchService';
-
-// Re-export validation utilities from emailBatchService for backwards compatibility
-export {
+import {
+    sendBulkEmails,
     validateAndCleanEmail,
     filterAndCleanEmails
 } from './emailBatchService';
+
+// Re-export validation utilities from emailBatchService for backwards compatibility
+export { validateAndCleanEmail, filterAndCleanEmails };
 
 /**
  * Generates HTML email template for an announcement


### PR DESCRIPTION
## Problem
The website was broken with error: `Uncaught ReferenceError: validateAndCleanEmail is not defined`

## Root Cause
The default export in `announcementEmailUtils.js` referenced `validateAndCleanEmail` and `filterAndCleanEmails` but they were only re-exported, not imported into the module scope.

## Solution
Import these functions from `emailBatchService` before re-exporting them, so they're available for the default export object.

## Testing
- ✅ Build succeeds locally
- ✅ No console errors in dev mode

## Urgency
🚨 **CRITICAL** - This fixes a production-breaking bug